### PR TITLE
Refactor: RestClient 설정 분리

### DIFF
--- a/src/main/java/com/vitaltrip/vitaltrip/config/RestClientConfig.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/config/RestClientConfig.java
@@ -1,8 +1,7 @@
 package com.vitaltrip.vitaltrip.config;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -10,47 +9,23 @@ import org.springframework.web.client.RestClient;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class RestClientConfig {
 
-    @Value("${gemini.api.base-url}")
-    private String geminiBaseUrl;
+    private final ClientHttpRequestInterceptor loggingInterceptor;
+    private final ClientHttpRequestInterceptor userAgentInterceptor;
+    private final ClientHttpRequestInterceptor errorHandlingInterceptor;
 
     @Bean
-    @Qualifier("geminiRestClient")
-    public RestClient geminiRestClient() {
+    public RestClient.Builder baseRestClientBuilder() {
         return RestClient.builder()
-            .baseUrl(geminiBaseUrl)
-            .requestInterceptor(loggingInterceptor())
-            .requestInterceptor(userAgentInterceptor())
-            .build();
+                .requestInterceptor(userAgentInterceptor)
+                .requestInterceptor(loggingInterceptor)
+                .requestInterceptor(errorHandlingInterceptor);
     }
 
     @Bean
-    @Qualifier("defaultRestClient")
-    public RestClient defaultRestClient() {
-        return RestClient.builder()
-            .requestInterceptor(loggingInterceptor())
-            .requestInterceptor(userAgentInterceptor())
-            .build();
-    }
-
-    private ClientHttpRequestInterceptor loggingInterceptor() {
-        return (request, body, execution) -> {
-            log.debug("RestClient Request: {} {}", request.getMethod(), request.getURI());
-
-            var response = execution.execute(request, body);
-
-            log.debug("RestClient Response: {} for {} {}",
-                response.getStatusCode(), request.getMethod(), request.getURI());
-
-            return response;
-        };
-    }
-
-    private ClientHttpRequestInterceptor userAgentInterceptor() {
-        return (request, body, execution) -> {
-            request.getHeaders().add("User-Agent", "VitalTrip/1.0.0 (Spring Boot)");
-            return execution.execute(request, body);
-        };
+    public RestClient defaultRestClient(RestClient.Builder baseRestClientBuilder) {
+        return baseRestClientBuilder.build();
     }
 }

--- a/src/main/java/com/vitaltrip/vitaltrip/config/interceptor/RestClientInterceptorConfig.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/config/interceptor/RestClientInterceptorConfig.java
@@ -1,0 +1,50 @@
+package com.vitaltrip.vitaltrip.config.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+
+@Slf4j
+@Configuration
+public class RestClientInterceptorConfig {
+
+    @Bean
+    public ClientHttpRequestInterceptor loggingInterceptor() {
+        return (request, body, execution) -> {
+            log.debug("RestClient Request: {} {}", request.getMethod(), request.getURI());
+
+            var response = execution.execute(request, body);
+
+            log.debug("RestClient Response: {} for {} {}",
+                    response.getStatusCode(), request.getMethod(), request.getURI());
+
+            return response;
+        };
+    }
+
+    @Bean
+    public ClientHttpRequestInterceptor userAgentInterceptor() {
+        return (request, body, execution) -> {
+            request.getHeaders().add("User-Agent", "VitalTrip/1.0.0 (Spring Boot)");
+            return execution.execute(request, body);
+        };
+    }
+
+    @Bean
+    public ClientHttpRequestInterceptor errorHandlingInterceptor() {
+        return (request, body, execution) -> {
+            try {
+                var response = execution.execute(request, body);
+                if (response.getStatusCode().isError()) {
+                    log.warn("HTTP Error Response: {} for {} {}",
+                            response.getStatusCode(), request.getMethod(), request.getURI());
+                }
+                return response;
+            } catch (Exception e) {
+                log.error("RestClient Error: {} {}", request.getMethod(), request.getURI(), e);
+                throw e;
+            }
+        };
+    }
+}

--- a/src/main/java/com/vitaltrip/vitaltrip/domain/ai/config/GeminiClientConfig.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/domain/ai/config/GeminiClientConfig.java
@@ -1,0 +1,29 @@
+package com.vitaltrip.vitaltrip.domain.ai.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class GeminiClientConfig {
+
+    private final RestClient.Builder baseRestClientBuilder;
+
+    @Value("${gemini.api.base-url}")
+    private String geminiBaseUrl;
+
+    @Bean
+    @Qualifier("geminiRestClient")
+    public RestClient geminiRestClient() {
+        return baseRestClientBuilder
+                .clone()
+                .baseUrl(geminiBaseUrl)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚩 연관 이슈

closed #27 

## 📝 작업 내용

의존성 분리를 위해 restClientConfig 내의 인터셉터, geminiClient 설정을 분리하였습니다.

## ✨ 참고 사항

## ⏰ 현재 버그

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
