### PR TITLE
Deploy: CI/CD 스크립트 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+      - run: chmod +x gradlew && ./gradlew build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-northeast-2
+  IMAGE: ${{ secrets.ECR_REGISTRY }}/vitaltrip-api
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - run: chmod +x gradlew && ./gradlew bootJar
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      - run: |
+          docker build -t $IMAGE:latest -t $IMAGE:${{ github.sha }} .
+          docker push -a $IMAGE
+
+      - name: Deploy
+        run: |
+          CID=$(aws ssm send-command \
+            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+            --document-name AWS-RunShellScript \
+            --parameters commands='[
+              "cd /home/ubuntu/app",
+              "aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login -u AWS --password-stdin ${{ secrets.ECR_REGISTRY }}",
+              "docker compose pull app",
+              "docker compose up -d app",
+              "docker image prune -af"
+            ]' --query Command.CommandId --output text)
+
+          aws ssm wait command-executed --command-id $CID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} || true
+
+          aws ssm get-command-invocation --command-id $CID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --query '[Status,StandardOutputContent,StandardErrorContent]' --output text


### PR DESCRIPTION
## 🚩 연관 이슈

closed #74 

## 📝 작업 내용

# Deploy: CI/CD 배포 방식 개선

## 문제 상황

기존 배포는 GitHub Actions에서 EC2에 SSH로 접속한 뒤 원격 명령을 실행하는 방식이었습니다.

이 방식은 배포 서버에 SSH 접속을 위한 인바운드 `22`번 포트를 열어두어야 하고, GitHub Actions에서 EC2에 접근하기 위한 SSH 키를 별도로 관리해야 했습니다.

또한 기존 스크립트에서는 원격 명령의 실제 실행 결과를 충분히 확인하지 않아, EC2에서 `docker pull`이나 컨테이너 재시작이 실패하더라도 GitHub Actions Job 자체는 성공으로 끝날 수 있는 문제가 있었습니다.

결과적으로 배포 과정에서 다음과 같은 문제가 있었습니다.

* EC2에 SSH 접속을 위한 `22`번 인바운드 포트 개방 필요
* GitHub Actions와 EC2 간 SSH 키 관리 필요
* 원격 배포 명령의 실제 성공 여부를 CI에서 명확하게 확인하기 어려움
* 배포 실패가 GitHub Actions의 성공으로 잘못 판단될 가능성

## 변경 사항

### 1. SSH 기반 배포를 AWS SSM 기반으로 변경

기존에는 GitHub Actions에서 SSH를 통해 EC2에 직접 접속했지만, AWS Systems Manager의 `Run Command`를 사용해 EC2에서 배포 명령을 실행하도록 변경했습니다.

```text
GitHub Actions
      │
      │ AWS SSM Run Command
      ▼
EC2
      │
      ├── ECR 로그인
      ├── Docker Compose 이미지 Pull
      ├── 컨테이너 재생성
      └── 사용하지 않는 이미지 정리
```

GitHub Actions에서는 다음 명령을 SSM을 통해 EC2에서 실행합니다.

```bash
cd /home/ubuntu/app
aws ecr get-login-password --region ${AWS_REGION} | docker login -u AWS --password-stdin ${ECR_REGISTRY}
docker compose pull app
docker compose up -d app
docker image prune -af
```

이를 통해 GitHub Actions가 EC2에 SSH로 직접 접속하지 않아도 배포 명령을 실행할 수 있도록 변경했습니다.

### 2. Docker 이미지 버전 관리

Docker 이미지를 `latest`와 Git commit SHA를 기준으로 각각 태깅하도록 변경했습니다.

```bash
docker build \
  -t $IMAGE:latest \
  -t $IMAGE:${{ github.sha }} .

docker push -a $IMAGE
```

`latest`는 현재 배포 대상 이미지를 가리키는 용도로 사용하고, commit SHA 태그를 함께 저장해 특정 커밋에서 생성된 이미지를 식별할 수 있도록 했습니다.

따라서 문제가 발생했을 때 어떤 커밋에서 생성된 이미지를 사용했는지 확인할 수 있고, 특정 버전의 이미지를 기준으로 롤백할 수 있는 기반을 마련했습니다.

### 3. 배포 동시 실행 방지

GitHub Actions의 `concurrency`를 사용해 배포 Job을 직렬화했습니다.

```yaml
concurrency:
  group: deploy
  cancel-in-progress: false
```

여러 커밋이 짧은 시간 내에 `main`에 반영되더라도 여러 배포가 동시에 EC2의 컨테이너를 변경하지 않도록 했습니다.

이를 통해 먼저 실행된 배포가 완료된 후 다음 배포가 실행되도록 구성했습니다.

### 4. 원격 명령 실행 결과 확인

SSM `send-command`를 통해 전달한 명령의 `CommandId`를 반환받고, 해당 명령의 실행 결과를 조회하도록 변경했습니다.

```bash
CID=$(aws ssm send-command \
  --instance-ids ${EC2_INSTANCE_ID} \
  --document-name AWS-RunShellScript \
  --parameters commands='[...]' \
  --query Command.CommandId \
  --output text)

aws ssm wait command-executed \
  --command-id $CID \
  --instance-id ${EC2_INSTANCE_ID}

aws ssm get-command-invocation \
  --command-id $CID \
  --instance-id ${EC2_INSTANCE_ID} \
  --query '[Status,StandardOutputContent,StandardErrorContent]' \
  --output text
```

이를 통해 EC2에서 실행된 배포 명령의 상태와 표준 출력, 표준 에러를 GitHub Actions에서 확인할 수 있도록 했습니다.

## 변경 후 배포 흐름

```text
GitHub Push
    │
    ▼
GitHub Actions
    │
    ├── Build
    │
    ├── Docker Image Build
    │      ├── :latest
    │      └── :{commit SHA}
    │
    ├── ECR Push
    │
    ▼
AWS SSM Run Command
    │
    ▼
EC2
    │
    ├── ECR Login
    ├── docker compose pull
    ├── docker compose up -d
    └── image prune
    │
    ▼
SSM 실행 결과 조회
```

## 결과

배포 방식을 SSH 기반에서 SSM 기반으로 변경하면서 GitHub Actions가 EC2의 SSH 포트로 직접 접근할 필요가 없어졌습니다.

또한 Docker 이미지에 commit SHA를 태깅하고 SSM 명령의 실행 결과를 조회하도록 구성해 **배포 대상 버전을 식별하고 원격 배포 명령의 성공 여부를 확인할 수 있는 기반**을 마련했습니다.

GitHub Actions의 `concurrency` 설정을 통해 배포 작업을 직렬화하여 여러 커밋의 배포가 동시에 EC2의 컨테이너를 변경하는 상황도 방지했습니다.

### 변경 전

```text
GitHub Actions
      │
      │ SSH :22
      ▼
     EC2
      │
      ▼
Docker Compose
```

### 변경 후

```text
GitHub Actions
      │
      │ SSM
      ▼
     EC2
      │
      ▼
Docker Compose

ECR
 ├── latest
 └── commit SHA
```

이를 통해 **SSH 포트에 의존하지 않는 배포 구조**, **배포 버전 추적 기반**, **원격 명령 결과를 활용한 배포 실패 감지 기반**을 확보했습니다.


## ✨ 참고 사항

## ⏰ 현재 버그

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
