### PR TITLE
Refactor: Flyway 도입으로 스키마 버전 관리 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ repositories {
 
 dependencies {
 
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     //Swagger
@@ -37,7 +36,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     //Database
-    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
@@ -56,9 +54,16 @@ dependencies {
     // Monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     //Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'org.testcontainers:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,17 +1,15 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:devdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
-    username: sa
-    password: ""
+    url: jdbc:mysql://db:3306/vitaltrip?characterEncoding=UTF-8&connectionTimeZone=Asia/Seoul
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
 
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  flyway:
+    enabled: true
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,7 +6,9 @@ spring:
     hikari:
       maximum-pool-size: ${DB_POOL_MAX:10}
       minimum-idle: 2
-
+  flyway:
+    enabled: true
+    baseline-on-migrate: false
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `users` (
+                         `id` BIGINT NOT NULL AUTO_INCREMENT,
+                         `created_at` DATETIME(6) NOT NULL,
+                         `updated_at` DATETIME(6) DEFAULT NULL,
+                         `birth_date` DATE DEFAULT NULL,
+                         `country_code` VARCHAR(2) DEFAULT NULL,
+                         `email` VARCHAR(255) NOT NULL,
+                         `name` VARCHAR(255) NOT NULL,
+                         `password_hash` VARCHAR(255) DEFAULT NULL,
+                         `phone_number` VARCHAR(20) DEFAULT NULL,
+                         `profile_image_url` VARCHAR(255) DEFAULT NULL,
+                         `provider` ENUM('GOOGLE','LOCAL') NOT NULL,
+                         `provider_id` VARCHAR(255) DEFAULT NULL,
+                         `role` ENUM('ADMIN','USER') NOT NULL,
+                         PRIMARY KEY (`id`),
+                         UNIQUE KEY `uk_users_email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/test/java/com/vitaltrip/vitaltrip/VitaltripApplicationTests.java
+++ b/src/test/java/com/vitaltrip/vitaltrip/VitaltripApplicationTests.java
@@ -2,10 +2,13 @@ package com.vitaltrip.vitaltrip;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import support.TestcontainersConfig;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestcontainersConfig.class)
 class VitaltripApplicationTests {
 
 	@Test

--- a/src/test/java/com/vitaltrip/vitaltrip/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/vitaltrip/vitaltrip/integration/AuthIntegrationTest.java
@@ -20,15 +20,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+import support.TestcontainersConfig;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Import(TestcontainersConfig.class)
 @Transactional
 @DisplayName("인증 통합 테스트")
 class AuthIntegrationTest {

--- a/src/test/java/support/TestcontainersConfig.java
+++ b/src/test/java/support/TestcontainersConfig.java
@@ -1,0 +1,17 @@
+package support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfig {
+
+    @Bean
+    @ServiceConnection
+    MySQLContainer<?> mysqlContainer() {
+        return new MySQLContainer<>("mysql:8.0")
+                .withReuse(true);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,11 +1,10 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
-    username: sa
-    password: ""
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
+
+  flyway:
+    enabled: true
 
 auth:
   jwt:


### PR DESCRIPTION
## 🚩 연관 이슈

closed #82 

## 📝 작업 내용

Flyway 도입으로 DB 스키마 버전 관리 전환
### 문제 상황

기존에는 JPA의 ddl-auto 설정을 통해 애플리케이션 실행 시 엔티티와 DB 스키마를 관리하고 있었습니다.

개발 과정에서 엔티티가 변경되면 로컬 DB에는 변경 사항이 반영되지만, 운영 DB의 스키마 변경은 별도로 관리해야 했습니다. 이로 인해 다음과 같은 문제가 있었습니다.

1. 로컬 DB와 운영 DB의 스키마 상태가 달라질 수 있음
2. 엔티티 변경에 필요한 운영 DB 스키마 변경 사항이 누락될 가능성이 있음
3. 스키마 변경 이력이 Git을 통해 명시적으로 관리되지 않음
4. 스키마 불일치가 배포 시점이 아닌 실제 API 요청 처리 과정에서 문제로 드러날 가능성이 있음

특히 운영 환경에서 Hibernate가 스키마를 직접 변경하도록 두는 것은 어떤 변경이 실제 DB에 적용되었는지 추적하기 어렵고, 운영 DB에 대한 예측하지 못한 변경이 발생할 수 있다는 문제가 있었습니다.

### 변경 사항
1. Flyway 도입

DB 스키마 변경을 SQL Migration 파일로 관리하도록 Flyway를 도입했습니다.
```
src/main/resources/db/migration/
├── V1__init.sql
```
각 Migration에는 버전을 부여하고 Git으로 함께 관리하여 스키마 변경 이력과 적용 순서를 코드 수준에서 추적할 수 있도록 했습니다.

Flyway는 Migration 적용 여부를 별도로 관리하기 때문에, 이미 적용된 스키마 변경은 다시 실행하지 않고 새로운 Migration만 순차적으로 적용할 수 있습니다.

2. 운영 환경의 ddl-auto 변경

기존에는 Hibernate의 ddl-auto를 통해 엔티티와 DB 스키마를 관리했지만, 운영 환경에서는 이를 validate로 변경했습니다.
```yml
spring:
  jpa:
    hibernate:
      ddl-auto: validate
```
validate에서는 Hibernate가 DB 스키마를 변경하지 않고, 애플리케이션 기동 과정에서 현재 엔티티 구조와 실제 DB 스키마가 일치하는지만 검증합니다.

따라서 운영 DB의 스키마 변경은 Flyway Migration을 통해서만 수행하고, Hibernate는 스키마 검증 역할만 담당하도록 책임을 분리했습니다.

변경 후 구조
```
                    Git
                     │
                     ▼
            Flyway Migration
                     │
                     ▼
              DB Schema 변경
                     │
                     ▼
              운영 DB Schema
                     ▲
                     │
              ddl-auto: validate
                     │
              Entity ↔ Schema 검증
```
즉,

Flyway: DB 스키마 변경
JPA/Hibernate: 엔티티와 DB 스키마 일치 여부 검증

으로 역할을 분리했습니다.

### 기대 효과
1. 스키마 변경 누락 조기 감지

엔티티와 DB 스키마가 일치하지 않는 경우 애플리케이션 기동 과정에서 검증에 실패합니다.

기존처럼 변경 사항이 누락된 상태로 애플리케이션이 실행되고 실제 API 요청 이후에 오류가 발생하는 상황을 방지할 수 있습니다.

2. 스키마 변경 이력 추적

모든 스키마 변경을 Migration 파일로 관리하기 때문에 Git을 통해 다음 내용을 추적할 수 있습니다.

어떤 스키마가 변경되었는지
언제 변경되었는지
어떤 순서로 변경되었는지
환경 간 스키마 일관성 확보

로컬에서 검증한 Migration을 운영 환경에서도 동일하게 적용할 수 있어, 환경별로 DB 스키마가 달라지는 문제를 줄일 수 있습니다.

### 결론

기존의 Hibernate 중심의 암묵적인 스키마 관리 방식에서 Flyway Migration을 통한 명시적인 버전 관리 방식으로 전환했습니다.

이를 통해 운영 DB의 변경 책임을 명확히 하고, 스키마 변경 이력을 코드로 추적할 수 있도록 했습니다. 또한 ddl-auto: validate를 통해 애플리케이션 기동 시점에 스키마 불일치를 검증하여 런타임 장애로 이어지는 문제를 사전에 발견할 수 있도록 개선했습니다.
## ✨ 참고 사항

## ⏰ 현재 버그

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
