### PR TITLE
Refactor: BigDataCloudConfig BaseUrl 설정파일로 분리

### DIFF
--- a/src/main/java/com/vitaltrip/vitaltrip/infra/location/config/BigDataCloudConfig.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/infra/location/config/BigDataCloudConfig.java
@@ -10,14 +10,12 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 public class BigDataCloudConfig {
 
-    private static final String BIG_DATA_CLOUD_BASE_URL = "https://api.bigdatacloud.net";
-
     @Bean
     @Qualifier("bigDataCloudRestClient")
-    public RestClient bigDataCloudRestClient(RestClient.Builder baseRestClientBuilder) {
+    public RestClient bigDataCloudRestClient(RestClient.Builder baseRestClientBuilder, BigDataCloudProperties properties) {
         return baseRestClientBuilder
-            .baseUrl(BIG_DATA_CLOUD_BASE_URL)
-            .defaultHeader("Content-Type", "application/json")
-            .build();
+                .baseUrl(properties.baseUrl())
+                .defaultHeader("Content-Type", "application/json")
+                .build();
     }
 }

--- a/src/main/java/com/vitaltrip/vitaltrip/infra/location/config/BigDataCloudProperties.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/infra/location/config/BigDataCloudProperties.java
@@ -1,0 +1,12 @@
+package com.vitaltrip.vitaltrip.infra.location.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "bigdatacloud.api")
+public record BigDataCloudProperties(
+        @NotBlank String baseUrl
+) {
+}

--- a/src/main/resources/config/places.yml
+++ b/src/main/resources/config/places.yml
@@ -4,3 +4,7 @@ google:
       base-url: https://places.googleapis.com/v1
       api-key: ${GOOGLE_PLACES_API_KEY}
       default-field-mask: places.displayName,places.formattedAddress,places.location,places.nationalPhoneNumber,places.currentOpeningHours,places.websiteUri
+
+bigdatacloud:
+  api:
+    base-url: ${BIG_DATA_CLOUD_BASE_URL:https://api.bigdatacloud.net}


### PR DESCRIPTION
## 🚩 연관 이슈

closed #85 

## 📝 작업 내용

원활한 환경변수 주입을 위해 BigDataCloudConfig BaseUrl을 설정파일로 분리하였습니다.

## ✨ 참고 사항

## ⏰ 현재 버그

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
