### PR TITLE
Feat: K6 부하테스트 환경 구축

### DIFF
--- a/docker-compose.loadtest.yml
+++ b/docker-compose.loadtest.yml
@@ -1,0 +1,66 @@
+name: vitaltrip-loadtest
+
+services:
+  stub:
+    image: wiremock/wiremock:3.9.1
+    volumes:
+      - ./k6/wiremock:/home/wiremock
+    command: [
+      "--async-response-enabled",
+      "--async-response-threads", "500",
+      "--container-threads", "1000",
+      "--no-request-journal"
+    ]
+    environment:
+      JAVA_OPTS: "-Xmx1g"
+    ports:
+      - "8090:8080"
+
+  db:
+    image: mysql:8.0
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --skip-performance-schema
+      --innodb-buffer-pool-size=128M
+    environment:
+      MYSQL_ROOT_PASSWORD: loadtest
+      MYSQL_DATABASE: vitaltrip
+      TZ: Asia/Seoul
+    healthcheck:
+      test: [ "CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -ploadtest --silent" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  app:
+    build: .
+    depends_on:
+      db:
+        condition: service_healthy
+      stub:
+        condition: service_started
+
+    environment:
+      SPRING_PROFILES_ACTIVE: loadtest
+      JAVA_TOOL_OPTIONS: "-Xmx700m -Duser.timezone=Asia/Seoul"
+
+      GEMINI_BASE_URL: http://stub:8080/v1beta/models
+      GEMINI_API_KEY: dummy
+      GEMINI_MODEL: gemini-3.5-flash
+      BIG_DATA_CLOUD_BASE_URL: http://stub:8080
+
+      GOOGLE_PLACES_API_KEY: dummy
+      NEWS_API_KEY: dummy
+      JWT_SECRET: loadtest-secret-key-must-be-at-least-32-bytes-long
+
+      DB_HOST: db
+      DB_NAME: vitaltrip
+      DB_USERNAME: root
+      DB_PASSWORD: loadtest
+      MYSQL_ROOT_PASSWORD: loadtest
+
+    ports:
+      - "8080:8080"
+      - "9090:9090"

--- a/k6/first-aid/baseline.js
+++ b/k6/first-aid/baseline.js
@@ -1,0 +1,35 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+export const options = {
+    vus: 1,
+    duration: '2m',
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+    },
+    summaryTrendStats: ['min', 'med', 'avg', 'p(90)', 'p(95)', 'max'],
+};
+
+export default function () {
+    const res = http.post(
+        `${BASE_URL}/api/first-aid/advice`,
+        JSON.stringify({
+            symptomType: 'BURNS',
+            symptomDetail: '뜨거운 물에 손을 데었어요',
+            latitude: 37.5665,
+            longitude: 126.978,
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+    );
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'country identified': (r) =>
+            r.json('data.identificationResponse.countryCode') === 'KR',
+        'ai response served': (r) => r.json('data.content') !== null,
+    });
+
+    sleep(1);
+}

--- a/k6/wiremock/mappings/bigdatacloud.json
+++ b/k6/wiremock/mappings/bigdatacloud.json
@@ -1,0 +1,21 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/data/reverse-geocode-client"
+  },
+  "response": {
+    "status": 200,
+    "fixedDelayMilliseconds": 300,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": {
+      "countryName": "South Korea",
+      "countryCode": "KR",
+      "principalSubdivision": "Seoul",
+      "locality": "Jung-gu",
+      "latitude": 37.5665,
+      "longitude": 126.978,
+      "localityLanguageRequested": "en"
+    }
+  }
+}

--- a/k6/wiremock/mappings/catch-all.json
+++ b/k6/wiremock/mappings/catch-all.json
@@ -1,0 +1,12 @@
+{
+  "priority": 99,
+  "request": {
+    "method": "ANY",
+    "urlPattern": ".*"
+  },
+  "response": {
+    "status": 599,
+    "headers": { "Content-Type": "text/plain" },
+    "body": "STUB_MISS"
+  }
+}

--- a/k6/wiremock/mappings/gemini.json
+++ b/k6/wiremock/mappings/gemini.json
@@ -1,0 +1,33 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/v1beta/models/[^/]+:generateContent"
+  },
+  "response": {
+    "status": 200,
+    "fixedDelayMilliseconds": 4000,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": {
+      "candidates": [
+        {
+          "content": {
+            "role": "model",
+            "parts": [
+              {
+                "text": "CONTENT:\nMove away from the heat source immediately\nCool the burn with cool running water for 10-15 minutes\nDo not apply ice directly to the burned area\nApply a loose sterile gauze bandage\nCall emergency services if the burn is severe or you are unsure\n\nSUMMARY:\nImmediate cooling and proper burn care are essential to prevent further tissue damage.\n\nRECOMMENDED_ACTION:\nCall emergency services immediately and cool the burn with running water\n\nDISCLAIMER:\nThis is temporary AI first aid advice. Please consult a medical professional as soon as possible."
+              }
+            ]
+          },
+          "finishReason": "STOP",
+          "index": 0
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 1450,
+        "candidatesTokenCount": 210,
+        "totalTokenCount": 1660
+      }
+    }
+  }
+}

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -1,0 +1,57 @@
+spring:
+  datasource:
+    url: jdbc:mysql://db:3306/vitaltrip?characterEncoding=UTF-8&connectionTimeZone=Asia/Seoul
+    username: root
+    password: ${MYSQL_ROOT_PASSWORD}
+
+  flyway:
+    enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+
+auth:
+  cookie:
+    domain: ""
+    secure: false
+    same-site: Lax
+
+app:
+  oauth2:
+    authorized-redirect-uri: http://localhost:3000/auth/callback
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
+
+logging:
+  level:
+    com.vitaltrip.vitaltrip: INFO
+    org.springframework.security: INFO
+    org.hibernate.SQL: INFO
+
+management:
+  server:
+    port: 9090
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,threaddump,heapdump,loggers
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: always
+      probes:
+        enabled: true


### PR DESCRIPTION
## 🚩 연관 이슈

closed #88

## 📝 작업 내용
# 부하 테스트

응급처치 가이드 API(`POST /api/first-aid/advice`)의 외부 의존성 검증을 위한 부하 테스트 환경입니다.

## 배경

이 API는 요청 하나를 처리하는 데 두 개의 외부 서비스를 거칩니다.

POST /api/first-aid/advice
→ BigDataCloud (좌표 → 국가 판별)
→ Gemini (응급처치 가이드 생성)
응답 시간의 대부분이 외부 서비스에 종속되므로, 외부 지연이 서비스 전체에 어떤 영향을 주는지 확인할 필요가 있습니다.

## 외부 API를 WireMock으로 대체하는 이유

실제 API로 부하 테스트를 하면 세 가지 문제가 있습니다.

- **과금** — 수만 건의 요청이 그대로 비용이 됩니다
- **쿼터** — 무료 한도에 걸려 테스트가 중간에 멈춥니다
- **제어 불가** — "Gemini가 60초 걸리는 상황"을 인위적으로 만들 수 없습니다

세 번째가 결정적입니다. 검증 대상이 장애 상황인데, 정상 동작하는 API로는 장애를 만들 수 없습니다.

WireMock은 응답 본문·상태 코드와 함께 **지연 시간**을 지정할 수 있어, 애플리케이션의 외부 API 주소만 바꿔 끼우면 코드 수정 없이 외부 의존을 대체할 수 있습니다.

## 실행

```bash
./gradlew bootJar
docker compose -f docker-compose.loadtest.yml up -d --build

k6 run k6/first-aid/baseline.js
```

기동 후 아래가 응답하면 정상입니다.

```bash
curl http://localhost:8080/                                  # 애플리케이션
curl http://localhost:9090/actuator/metrics                   # 메트릭 (management 포트)
curl http://localhost:8090/__admin/mappings                   # WireMock 스텁
```

## 구성

| 서비스 | 포트 | 역할 |
| --- | --- | --- |
| app | 8080 / 9090 | 애플리케이션 / 액추에이터 |
| stub | 8090 | WireMock (외부 API 대체) |
| db | - | MySQL |

WireMock에는 다음 옵션을 적용했습니다. 기본 설정으로는 60초 지연 응답을 다수 동시에 유지할 때 스텁 자체가 먼저 포화되어, 서버 성능인지 스텁 한계인지 구분할 수 없게 됩니다.

- `--async-response-enabled`, `--async-response-threads 500` — 지연 응답을 비동기로 처리
- `--container-threads 1000` — 동시 연결 수 확보
- `--no-request-journal` — 요청 기록 누적으로 인한 메모리 증가 방지

## 스텁

`wiremock/mappings/` 아래 매핑 파일이 위치합니다.

| 파일 | 대상 | 기본 지연 |
| --- | --- | --- |
| `gemini.json` | Gemini generateContent | 4000ms |
| `bigdatacloud.json` | 좌표 → 국가 판별 | 300ms |
| `catch-all.json` | 정의되지 않은 모든 경로 | - |

`catch-all.json`은 매칭되지 않은 요청에 599와 `STUB_MISS`를 반환합니다. 이것이 없으면 스텁 설정에 오타가 있어도 WireMock이 기본 404를 반환하고, 애플리케이션은 이를 정상적인 실패로 처리합니다. **테스트가 통과했는데 실제로는 아무것도 검증하지 못한 상태**가 가장 위험하므로, 스텁 미스를 명시적으로 감지할 수 있게 했습니다.

## 스크립트

### baseline.js

부하가 없는 상태의 응답 시간을 측정합니다. 비교 기준이 없으면 이후 수치가 좋은지 나쁜지 판단할 수 없으므로, 모든 측정에 앞서 실행합니다.

```bash
k6 run k6/first-aid/baseline.js
```

VU 1로 2분간 순차 호출하며, 응답 코드뿐 아니라 **국가 판별 결과와 본문 내용까지 검증**합니다. 상태 코드만 확인하면 내부에서 fallback 응답으로 대체된 경우를 정상으로 오인할 수 있습니다.

**측정 결과**

| 지표 | 값 |
| --- | --- |
| 응답 시간 (p95) | 4.32s |
| 실패율 | 0% |

4.31초는 스텁 지연 4초 + 서버 처리 0.31초입니다. 즉 **이 기능의 이론적 최소 응답 시간**이며, 이후 모든 측정은 이 값과 비교합니다.

## 환경 변수

| 변수 | 기본값 |
| --- | --- |
| `BASE_URL` | `http://localhost:8080` |
| `MGMT_URL` | `http://localhost:9090` |
| `STUB_ADMIN_URL` | `http://localhost:8090/__admin` |

```bash
k6 run -e BASE_URL=http://192.168.0.10:8080 k6/first-aid/baseline.js
```
## ✨ 참고 사항

## ⏰ 현재 버그

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
