### PR TITLE
Feat: 응급처치 가이드 제공 기능 타임아웃 적용

### DIFF
--- a/k6/first-aid/fault-isolation.js
+++ b/k6/first-aid/fault-isolation.js
@@ -1,0 +1,198 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const MGMT_URL = __ENV.MGMT_URL || 'http://localhost:9090';
+const STUB_ADMIN_URL = __ENV.STUB_ADMIN_URL || 'http://localhost:8090/__admin';
+
+const SYMPTOM_TYPES = ['BLEEDING', 'BURNS', 'FRACTURE', 'ALLERGIC_REACTION', 'SEIZURE'];
+const JSON_HEADERS = { headers: { 'Content-Type': 'application/json' } };
+
+const NORMAL_DELAY_MS = 4000;
+const DEGRADED_DELAY_MS = 60000;
+
+const DEGRADE_START_SEC = 120;
+const DEGRADE_END_SEC = 300;
+const TEST_DURATION_SEC = 600;
+
+const GEMINI_STUB_TEXT = [
+    'CONTENT:',
+    'Move away from the heat source immediately',
+    'Cool the burn with cool running water for 10-15 minutes',
+    'Do not apply ice directly to the burned area',
+    'Apply a loose sterile gauze bandage',
+    'Call emergency services if the burn is severe or you are unsure',
+    '',
+    'SUMMARY:',
+    'Immediate cooling and proper burn care are essential to prevent further tissue damage.',
+    '',
+    'RECOMMENDED_ACTION:',
+    'Call emergency services immediately and cool the burn with running water',
+    '',
+    'DISCLAIMER:',
+    'This is temporary AI first aid advice. Please consult a medical professional as soon as possible.',
+].join('\n');
+
+const tomcatBusyThreads = new Trend('tomcat_busy_threads');
+const stubMiss = new Counter('stub_miss');
+
+export const options = {
+    scenarios: {
+        firstAidLoad: {
+            executor: 'constant-arrival-rate',
+            rate: 4,
+            timeUnit: '1s',
+            duration: `${TEST_DURATION_SEC}s`,
+            preAllocatedVUs: 50,
+            maxVUs: 3000,
+            exec: 'requestFirstAid',
+        },
+        faultInjection: {
+            executor: 'shared-iterations',
+            vus: 1,
+            iterations: 2,
+            startTime: `${DEGRADE_START_SEC}s`,
+            maxDuration: '8m',
+            exec: 'injectFault',
+        },
+        canary: {
+            executor: 'constant-arrival-rate',
+            rate: 1,
+            timeUnit: '2s',
+            duration: `${TEST_DURATION_SEC}s`,
+            preAllocatedVUs: 5,
+            maxVUs: 50,
+            exec: 'probeUnrelatedEndpoint',
+        },
+        monitor: {
+            executor: 'constant-arrival-rate',
+            rate: 1,
+            timeUnit: '1s',
+            duration: `${TEST_DURATION_SEC}s`,
+            preAllocatedVUs: 1,
+            maxVUs: 1,
+            exec: 'observeServerState',
+        },
+    },
+    thresholds: {
+        'http_req_duration{scenario:canary}': ['p(95)<2000'],
+        'http_req_failed{scenario:canary}': ['rate<0.05'],
+        tomcat_busy_threads: ['max<200'],
+        stub_miss: ['count<5'],
+    },
+    summaryTrendStats: ['min', 'med', 'avg', 'p(90)', 'p(95)', 'p(99)', 'max'],
+};
+
+function setGeminiDelay(delayMs) {
+    http.post(`${STUB_ADMIN_URL}/mappings/reset`, null);
+    http.post(
+        `${STUB_ADMIN_URL}/mappings`,
+        JSON.stringify({
+            priority: 0,
+            request: {
+                method: 'POST',
+                urlPathPattern: '/v1beta/models/[^/]+:generateContent',
+            },
+            response: {
+                status: 200,
+                fixedDelayMilliseconds: delayMs,
+                headers: { 'Content-Type': 'application/json' },
+                jsonBody: {
+                    candidates: [
+                        {
+                            content: { role: 'model', parts: [{ text: GEMINI_STUB_TEXT }] },
+                            finishReason: 'STOP',
+                            index: 0,
+                        },
+                    ],
+                },
+            },
+        }),
+        JSON_HEADERS
+    );
+}
+
+function phaseAt(elapsedSec) {
+    if (elapsedSec < DEGRADE_START_SEC) return 'normal';
+    if (elapsedSec < DEGRADE_END_SEC) return 'degraded';
+    return 'recovery';
+}
+
+export function setup() {
+    setGeminiDelay(NORMAL_DELAY_MS);
+
+    const probe = http.post(
+        `${BASE_URL}/api/first-aid/advice`,
+        JSON.stringify({
+            symptomType: 'BURNS',
+            symptomDetail: 'warmup',
+            latitude: 37.5665,
+            longitude: 126.978,
+        }),
+        { ...JSON_HEADERS, timeout: '30s' }
+    );
+
+    if (probe.status !== 200) {
+        console.error(`[setup] warmup failed with status ${probe.status}`);
+    }
+
+    return { startedAt: Date.now() };
+}
+
+let injectionStep = 0;
+
+export function injectFault() {
+    const delayMs = injectionStep++ === 0 ? DEGRADED_DELAY_MS : NORMAL_DELAY_MS;
+    console.log(`[fault] gemini delay -> ${delayMs}ms`);
+    setGeminiDelay(delayMs);
+    sleep(DEGRADE_END_SEC - DEGRADE_START_SEC);
+}
+
+export function requestFirstAid(data) {
+    const phase = phaseAt((Date.now() - data.startedAt) / 1000);
+
+    const res = http.post(
+        `${BASE_URL}/api/first-aid/advice`,
+        JSON.stringify({
+            symptomType: SYMPTOM_TYPES[__ITER % SYMPTOM_TYPES.length],
+            symptomDetail: '계단에서 넘어져 다리에서 피가 많이 납니다',
+            latitude: 37.5665,
+            longitude: 126.978,
+        }),
+        { ...JSON_HEADERS, timeout: '180s', tags: { phase } }
+    );
+
+    if (res.status === 599 || String(res.body).includes('STUB_MISS')) {
+        stubMiss.add(1);
+    }
+
+    check(res, { 'status is 200': (r) => r.status === 200 }, { phase });
+}
+
+export function probeUnrelatedEndpoint(data) {
+    const phase = phaseAt((Date.now() - data.startedAt) / 1000);
+    const res = http.get(`${BASE_URL}/`, { timeout: '30s', tags: { phase } });
+    check(res, { 'canary alive': (r) => r.status === 200 });
+}
+
+export function observeServerState(data) {
+    const elapsedSec = Math.round((Date.now() - data.startedAt) / 1000);
+
+    const threadsRes = http.get(`${MGMT_URL}/actuator/metrics/tomcat.threads.busy`, {
+        tags: { name: 'monitor' },
+    });
+
+    let busyThreads = null;
+    if (threadsRes.status === 200) {
+        busyThreads = threadsRes.json('measurements.0.value');
+        tomcatBusyThreads.add(busyThreads);
+    }
+
+    console.log(`t=${elapsedSec}s phase=${phaseAt(elapsedSec)} busy=${busyThreads}`);
+}
+
+export function teardown() {
+    setGeminiDelay(NORMAL_DELAY_MS);
+    console.log('[teardown] gemini delay restored');
+}

--- a/src/main/java/com/vitaltrip/vitaltrip/infra/config/RestClientConfig.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/infra/config/RestClientConfig.java
@@ -28,4 +28,5 @@ public class RestClientConfig {
     public RestClient defaultRestClient(RestClient.Builder baseRestClientBuilder) {
         return baseRestClientBuilder.build();
     }
+
 }

--- a/src/main/java/com/vitaltrip/vitaltrip/infra/config/SecurityConfig.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/infra/config/SecurityConfig.java
@@ -7,8 +7,10 @@ import com.vitaltrip.vitaltrip.presentation.auth.handler.SimpleOAuth2SuccessHand
 import java.util.Arrays;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -31,6 +33,17 @@ public class SecurityConfig {
     private final FirstAidAuthenticationFilter firstAidAuthenticationFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final SimpleOAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    @Order(0)
+    @Profile("loadtest")
+    public SecurityFilterChain actuatorFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher(EndpointRequest.toAnyEndpoint())
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .build();
+    }
 
     @Bean
     @Order(1)

--- a/src/main/java/com/vitaltrip/vitaltrip/infra/gemini/config/GeminiClientConfig.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/infra/gemini/config/GeminiClientConfig.java
@@ -1,27 +1,22 @@
 package com.vitaltrip.vitaltrip.infra.gemini.config;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
-@Slf4j
 @Configuration
-@RequiredArgsConstructor
 public class GeminiClientConfig {
 
-    private final RestClient.Builder baseRestClientBuilder;
-    private final GeminiClientProperties properties;
-
     @Bean
-    @Qualifier("geminiRestClient")
-    public RestClient geminiRestClient() {
-        return baseRestClientBuilder
-                .clone()
+    public RestClient geminiRestClient(GeminiClientProperties properties) {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.connectTimeout());
+        factory.setReadTimeout(properties.readTimeout());
+
+        return RestClient.builder()
                 .baseUrl(properties.baseUrl())
+                .requestFactory(factory)
                 .build();
     }
 }

--- a/src/main/java/com/vitaltrip/vitaltrip/infra/gemini/config/GeminiClientProperties.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/infra/gemini/config/GeminiClientProperties.java
@@ -1,14 +1,19 @@
 package com.vitaltrip.vitaltrip.infra.gemini.config;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
 
 @Validated
 @ConfigurationProperties(prefix = "ai.gemini")
 public record GeminiClientProperties(
         @NotBlank String apiKey,
         @NotBlank String baseUrl,
-        @NotBlank String model
+        @NotBlank String model,
+        @NotNull Duration connectTimeout,
+        @NotNull Duration readTimeout
 ) {
 }

--- a/src/main/resources/config/ai.yml
+++ b/src/main/resources/config/ai.yml
@@ -3,3 +3,5 @@ ai:
     api-key: ${GEMINI_API_KEY}
     base-url: ${GEMINI_BASE_URL:https://generativelanguage.googleapis.com/v1beta/models}
     model: ${GEMINI_MODEL:gemini-3.5-flash}
+    connect-timeout: 3s
+    read-timeout: 8s


### PR DESCRIPTION
## 🚩 연관 이슈

closed #90 

## 📝 작업 내용

## 결과

| 지표 | before | after |
| --- | --- | --- |
| 톰캣 스레드 점유 (max) | 200 | 23 |
| canary p95 | 1.55s | 3.29ms |
| 응답 시간 p95 | 1m 0s | 8.31s |
| 요청 실패율 | 0.00% | 21.7% |

Gemini를 호출하지 않는 `GET /`의 p95가 1.55초에서 3.29ms로 회복되어,
장애 전파가 차단된 것을 확인했습니다.

실패율 증가는 타임아웃의 의도된 결과입니다.
8초를 초과하는 호출을 포기하는 대신 다른 기능의 가용성을 확보하였습니다.

## 남은 문제

응답 시간이 p90부터 p99까지 모두 8.31초로 동일합니다.
장애 구간의 모든 요청이 8초를 대기한 뒤 실패한다는 의미이며, 외부 서비스가 이미 응답
불가 상태임을 알면서도 매 요청마다 확인하고 있습니다 -> 서킷 브레이커로 개선 예정.

## ✨ 참고 사항

## ⏰ 현재 버그

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
