### PR TITLE
Feat: 응급처치 가이드 제공 기능 서킷 브레이크 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     //Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/k6/first-aid/fault-isolation.js
+++ b/k6/first-aid/fault-isolation.js
@@ -1,6 +1,6 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { Trend, Counter } from 'k6/metrics';
+import { Trend, Rate, Counter } from 'k6/metrics';
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const MGMT_URL = __ENV.MGMT_URL || 'http://localhost:9090';
@@ -35,6 +35,9 @@ const GEMINI_STUB_TEXT = [
 ].join('\n');
 
 const tomcatBusyThreads = new Trend('tomcat_busy_threads');
+const circuitOpenRate = new Rate('circuit_open_rate');
+const fallbackRate = new Rate('fallback_rate');
+const recoveryLag = new Trend('recovery_lag_ms');
 const stubMiss = new Counter('stub_miss');
 
 export const options = {
@@ -167,7 +170,23 @@ export function requestFirstAid(data) {
         stubMiss.add(1);
     }
 
-    check(res, { 'status is 200': (r) => r.status === 200 }, { phase });
+    const servedByFallback =
+        res.status === 200 && res.json('data.aiAvailable') === false;
+    fallbackRate.add(servedByFallback, { phase });
+
+    check(
+        res,
+        {
+            'status is 200': (r) => r.status === 200,
+            'actionable response': (r) => {
+                const data = r.json('data');
+                return data.aiAvailable === true
+                    ? data.content !== null
+                    : data.identificationResponse.emergencyContact !== null;
+            },
+        },
+        { phase }
+    );
 }
 
 export function probeUnrelatedEndpoint(data) {
@@ -175,6 +194,9 @@ export function probeUnrelatedEndpoint(data) {
     const res = http.get(`${BASE_URL}/`, { timeout: '30s', tags: { phase } });
     check(res, { 'canary alive': (r) => r.status === 200 });
 }
+
+let lastCircuitState = null;
+let circuitOpenedAt = null;
 
 export function observeServerState(data) {
     const elapsedSec = Math.round((Date.now() - data.startedAt) / 1000);
@@ -189,7 +211,40 @@ export function observeServerState(data) {
         tomcatBusyThreads.add(busyThreads);
     }
 
-    console.log(`t=${elapsedSec}s phase=${phaseAt(elapsedSec)} busy=${busyThreads}`);
+    const circuitRes = http.get(`${MGMT_URL}/actuator/circuitbreakers`, {
+        tags: { name: 'monitor' },
+    });
+
+    let circuitState = 'N/A';
+    if (circuitRes.status === 200) {
+        circuitState = circuitRes.json('circuitBreakers.gemini.state') || 'UNKNOWN';
+        circuitOpenRate.add(circuitState === 'OPEN' || circuitState === 'FORCED_OPEN');
+
+        if (circuitState !== lastCircuitState) {
+            console.log(`[circuit] ${lastCircuitState} -> ${circuitState} (t=${elapsedSec}s)`);
+
+            if (circuitState === 'OPEN' && circuitOpenedAt === null) {
+                circuitOpenedAt = Date.now();
+            }
+
+            if (
+                circuitState === 'CLOSED' &&
+                circuitOpenedAt !== null &&
+                elapsedSec > DEGRADE_END_SEC
+            ) {
+                const lagMs = Date.now() - (data.startedAt + DEGRADE_END_SEC * 1000);
+                recoveryLag.add(lagMs);
+                console.log(`[circuit] recovered in ${Math.round(lagMs / 1000)}s`);
+                circuitOpenedAt = null;
+            }
+
+            lastCircuitState = circuitState;
+        }
+    }
+
+    console.log(
+        `t=${elapsedSec}s phase=${phaseAt(elapsedSec)} busy=${busyThreads} circuit=${circuitState}`
+    );
 }
 
 export function teardown() {

--- a/src/main/java/com/vitaltrip/vitaltrip/application/first_aid/FirstAidService.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/application/first_aid/FirstAidService.java
@@ -8,6 +8,7 @@ import com.vitaltrip.vitaltrip.presentation.first_aid.dto.GeminiParsedResponse;
 import com.vitaltrip.vitaltrip.presentation.location.dto.CountryIdentificationRequest;
 import com.vitaltrip.vitaltrip.presentation.location.dto.CountryIdentificationResponse;
 import com.vitaltrip.vitaltrip.application.location.LocationService;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,11 +33,12 @@ public class FirstAidService {
     private final AiResponseParser aiResponseParser;
     private final LocationService locationService;
 
+    @CircuitBreaker(name = "gemini", fallbackMethod = "adviceFallback")
     public EmergencyChatAdviceResponse generateEmergencyAdvice(EmergencyChatAdviceRequest request) {
 
         CountryIdentificationResponse identificationResponse = locationService.identifyCountry(
-            new CountryIdentificationRequest(
-                request.latitude(), request.longitude()));
+                new CountryIdentificationRequest(
+                        request.latitude(), request.longitude()));
 
         String prompt = promptService.buildPrompt(request.symptomType(), request.symptomDetail());
         String aiResponse = geminiClient.generateContent(prompt);
@@ -45,14 +49,32 @@ public class FirstAidService {
         List<String> blogLinks = getBlogLinks(request.symptomType(), "en");
 
         return EmergencyChatAdviceResponse.of(
-            parsedResponse.content(),
-            parsedResponse.summary(),
-            parsedResponse.recommendedAction(),
-            identificationResponse,
-            parsedResponse.disclaimer(),
-            confidence,
-            blogLinks
+                parsedResponse.content(),
+                parsedResponse.summary(),
+                parsedResponse.recommendedAction(),
+                identificationResponse,
+                parsedResponse.disclaimer(),
+                confidence,
+                blogLinks
         );
+    }
+
+    private EmergencyChatAdviceResponse adviceFallback(
+            EmergencyChatAdviceRequest request, Throwable t) {
+
+        log.warn("Gemini 호출 차단 - 응급 연락처 안내로 대체: {}", t.getClass().getSimpleName());
+
+        CountryIdentificationResponse identification;
+        try {
+            identification = locationService.identifyCountry(
+                    new CountryIdentificationRequest(request.latitude(), request.longitude()));
+        } catch (Exception e) {
+            log.warn("폴백 중 국가 판별 실패 - 기본 안내로 대체", e);
+            identification = CountryIdentificationResponse.unknown(
+                    request.latitude(), request.longitude());
+        }
+
+        return EmergencyChatAdviceResponse.unavailable(identification);
     }
 
     private Integer calculateConfidence(String content, EmergencySymptomType symptomType) {
@@ -120,9 +142,9 @@ public class FirstAidService {
         }
 
         long meaningfulSteps = Arrays.stream(steps)
-            .filter(step -> step.trim().length() > 5)
-            .filter(step -> !step.trim().matches("^[\\s\\p{Punct}]*$"))
-            .count();
+                .filter(step -> step.trim().length() > 5)
+                .filter(step -> !step.trim().matches("^[\\s\\p{Punct}]*$"))
+                .count();
 
         if (meaningfulSteps < steps.length * 0.9) {
             structureScore -= 5;
@@ -136,24 +158,24 @@ public class FirstAidService {
         String lowerContent = content.toLowerCase();
 
         List<String> emergencyActionKeywords = Arrays.asList(
-            // 영어
-            "call", "contact", "apply", "remove", "check", "monitor", "position", "clean", "cover",
-            "press",
-            "elevate", "immobilize", "cool", "warm", "rinse", "seek", "emergency", "hospital",
-            "doctor",
-            // 한국어
-            "연락", "신고", "확인", "제거", "압박", "올리", "고정", "냉각", "따뜻", "씻", "덮", "병원", "의사", "응급",
-            // 일본어
-            "連絡", "確認", "除去", "圧迫", "固定", "冷却", "洗", "覆", "病院", "医師", "救急",
-            // 기타 언어들의 핵심 단어들
-            "llamar", "aplicar", "limpiar", "hospital", // 스페인어
-            "appeler", "appliquer", "nettoyer", "hôpital", // 프랑스어
-            "rufen", "anwenden", "reinigen", "krankenhaus" // 독일어
+                // 영어
+                "call", "contact", "apply", "remove", "check", "monitor", "position", "clean", "cover",
+                "press",
+                "elevate", "immobilize", "cool", "warm", "rinse", "seek", "emergency", "hospital",
+                "doctor",
+                // 한국어
+                "연락", "신고", "확인", "제거", "압박", "올리", "고정", "냉각", "따뜻", "씻", "덮", "병원", "의사", "응급",
+                // 일본어
+                "連絡", "確認", "除去", "圧迫", "固定", "冷却", "洗", "覆", "病院", "医師", "救急",
+                // 기타 언어들의 핵심 단어들
+                "llamar", "aplicar", "limpiar", "hospital", // 스페인어
+                "appeler", "appliquer", "nettoyer", "hôpital", // 프랑스어
+                "rufen", "anwenden", "reinigen", "krankenhaus" // 독일어
         );
 
         long keywordCount = emergencyActionKeywords.stream()
-            .mapToLong(keyword -> countOccurrences(lowerContent, keyword))
-            .sum();
+                .mapToLong(keyword -> countOccurrences(lowerContent, keyword))
+                .sum();
 
         if (keywordCount >= 8) {
             qualityScore += 8;
@@ -169,13 +191,13 @@ public class FirstAidService {
         }
 
         List<String> warningKeywords = Arrays.asList(
-            "주의", "조심", "위험", "금지", "하지마", "avoid", "don't", "never", "warning", "careful",
-            "注意", "避ける", "危険", "cuidado", "evitar", "peligro", "attention", "éviter",
-            "danger"
+                "주의", "조심", "위험", "금지", "하지마", "avoid", "don't", "never", "warning", "careful",
+                "注意", "避ける", "危険", "cuidado", "evitar", "peligro", "attention", "éviter",
+                "danger"
         );
 
         boolean hasWarnings = warningKeywords.stream()
-            .anyMatch(keyword -> lowerContent.contains(keyword));
+                .anyMatch(keyword -> lowerContent.contains(keyword));
         if (hasWarnings) {
             qualityScore += 4;
         }
@@ -188,48 +210,48 @@ public class FirstAidService {
         String lowerContent = content.toLowerCase();
 
         Map<EmergencySymptomType, List<String>> typeKeywords = Map.of(
-            EmergencySymptomType.BLEEDING, Arrays.asList(
-                "pressure", "압박", "지혈", "elevate", "올리", "bandage", "거즈", "clean", "깨끗"
-            ),
-            EmergencySymptomType.BURNS, Arrays.asList(
-                "cool", "cold", "차가운", "냉각", "water", "물", "ice", "얼음", "remove", "제거"
-            ),
-            EmergencySymptomType.FRACTURE, Arrays.asList(
-                "immobilize", "고정", "splint", "부목", "support", "지지", "move", "움직이지"
-            ),
-            EmergencySymptomType.ALLERGIC_REACTION, Arrays.asList(
-                "epinephrine", "에피펜", "antihistamine", "항히스타민", "breathing", "호흡", "swelling", "부종"
-            ),
-            EmergencySymptomType.SEIZURE, Arrays.asList(
-                "protect", "보호", "side", "옆으로", "time", "시간", "recovery", "회복", "clear", "치우"
-            )
+                EmergencySymptomType.BLEEDING, Arrays.asList(
+                        "pressure", "압박", "지혈", "elevate", "올리", "bandage", "거즈", "clean", "깨끗"
+                ),
+                EmergencySymptomType.BURNS, Arrays.asList(
+                        "cool", "cold", "차가운", "냉각", "water", "물", "ice", "얼음", "remove", "제거"
+                ),
+                EmergencySymptomType.FRACTURE, Arrays.asList(
+                        "immobilize", "고정", "splint", "부목", "support", "지지", "move", "움직이지"
+                ),
+                EmergencySymptomType.ALLERGIC_REACTION, Arrays.asList(
+                        "epinephrine", "에피펜", "antihistamine", "항히스타민", "breathing", "호흡", "swelling", "부종"
+                ),
+                EmergencySymptomType.SEIZURE, Arrays.asList(
+                        "protect", "보호", "side", "옆으로", "time", "시간", "recovery", "회복", "clear", "치우"
+                )
         );
 
         typeKeywords = new HashMap<>(typeKeywords);
         typeKeywords.put(EmergencySymptomType.HEATSTROKE, Arrays.asList(
-            "cool", "shade", "그늘", "냉각", "temperature", "체온", "hydrate", "수분"
+                "cool", "shade", "그늘", "냉각", "temperature", "체온", "hydrate", "수분"
         ));
         typeKeywords.put(EmergencySymptomType.HYPOTHERMIA, Arrays.asList(
-            "warm", "따뜻", "gradual", "서서히", "blanket", "담요", "dry", "건조"
+                "warm", "따뜻", "gradual", "서서히", "blanket", "담요", "dry", "건조"
         ));
         typeKeywords.put(EmergencySymptomType.POISONING, Arrays.asList(
-            "poison control", "독성", "flush", "씻어", "vomit", "토하지", "identify", "확인"
+                "poison control", "독성", "flush", "씻어", "vomit", "토하지", "identify", "확인"
         ));
         typeKeywords.put(EmergencySymptomType.BREATHING_DIFFICULTY, Arrays.asList(
-            "airway", "기도", "position", "자세", "inhaler", "흡입기", "oxygen", "산소"
+                "airway", "기도", "position", "자세", "inhaler", "흡입기", "oxygen", "산소"
         ));
         typeKeywords.put(EmergencySymptomType.ANIMAL_BITE, Arrays.asList(
-            "wash", "씻", "rabies", "광견병", "infection", "감염", "tetanus", "파상풍"
+                "wash", "씻", "rabies", "광견병", "infection", "감염", "tetanus", "파상풍"
         ));
         typeKeywords.put(EmergencySymptomType.FALL_INJURY, Arrays.asList(
-            "spinal", "척추", "head", "머리", "conscious", "의식", "neck", "목"
+                "spinal", "척추", "head", "머리", "conscious", "의식", "neck", "목"
         ));
 
         List<String> relevantKeywords = typeKeywords.getOrDefault(symptomType,
-            Collections.emptyList());
+                Collections.emptyList());
         long matchCount = relevantKeywords.stream()
-            .mapToLong(keyword -> countOccurrences(lowerContent, keyword))
-            .sum();
+                .mapToLong(keyword -> countOccurrences(lowerContent, keyword))
+                .sum();
 
         if (matchCount >= 3) {
             relevanceScore += 8;
@@ -282,15 +304,15 @@ public class FirstAidService {
         String lowerContent = content.toLowerCase();
 
         List<String> safetyKeywords = Arrays.asList(
-            "emergency", "911", "119", "112", "응급", "구급차", "ambulance", "hospital", "병원",
-            "doctor", "의사", "professional", "전문", "medical", "의료", "immediate", "즉시",
-            "救急", "医師", "病院", "urgence", "médecin", "hôpital", "notfall", "arzt",
-            "krankenhaus"
+                "emergency", "911", "119", "112", "응급", "구급차", "ambulance", "hospital", "병원",
+                "doctor", "의사", "professional", "전문", "medical", "의료", "immediate", "즉시",
+                "救急", "医師", "病院", "urgence", "médecin", "hôpital", "notfall", "arzt",
+                "krankenhaus"
         );
 
         long safetyKeywordCount = safetyKeywords.stream()
-            .mapToLong(keyword -> countOccurrences(lowerContent, keyword))
-            .sum();
+                .mapToLong(keyword -> countOccurrences(lowerContent, keyword))
+                .sum();
 
         if (safetyKeywordCount >= 2) {
             return 5;
@@ -329,119 +351,119 @@ public class FirstAidService {
 
         // 3. 중복 제거 및 최대 5개로 제한
         return links.stream()
-            .distinct()
-            .limit(5)
-            .collect(Collectors.toList());
+                .distinct()
+                .limit(5)
+                .collect(Collectors.toList());
     }
 
 
     private List<String> getBaseEmergencyResourcesByLanguage(String language) {
         return switch (language.toLowerCase()) {
             case "ko" -> Arrays.asList(
-                // 한국 공식 기관
-                "https://www.119.go.kr/main.do", // 소방청 공식 사이트
-                "https://www.safekorea.go.kr/idsiSFK/neo/sfk/cs/contents/civil_defense/SDIJKM1401.html",
-                // 행정안전부 재난대응
-                "https://www.redcross.or.kr/webapp/homepage/hp30100/hp30100.jsp?menuId=HP30101",
-                // 대한적십자사
-                "https://www.mohw.go.kr/react/policy/policy_bd_vw.jsp?PAR_MENU_ID=04&MENU_ID=0403&CONT_SEQ=334927",
-                // 보건복지부
-                "https://blog.naver.com/koreaemergency" // 응급의학 정보 블로그
+                    // 한국 공식 기관
+                    "https://www.119.go.kr/main.do", // 소방청 공식 사이트
+                    "https://www.safekorea.go.kr/idsiSFK/neo/sfk/cs/contents/civil_defense/SDIJKM1401.html",
+                    // 행정안전부 재난대응
+                    "https://www.redcross.or.kr/webapp/homepage/hp30100/hp30100.jsp?menuId=HP30101",
+                    // 대한적십자사
+                    "https://www.mohw.go.kr/react/policy/policy_bd_vw.jsp?PAR_MENU_ID=04&MENU_ID=0403&CONT_SEQ=334927",
+                    // 보건복지부
+                    "https://blog.naver.com/koreaemergency" // 응급의학 정보 블로그
             );
 
             case "ja" -> Arrays.asList(
-                // 일본 공식 기관
-                "https://www.jrc.or.jp/activity/study/safety/", // 일본적십자사
-                "https://www.fdma.go.jp/mission/prevention/kinkyu/", // 소방청 응급처치
-                "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000121431.html", // 후생노동성
-                "https://www.city.tokyo.lg.jp/shobo/anzen/topics/saigai/kyukyu/", // 도쿄소방청
-                "https://www.med.or.jp/people/info/people_info/000380.html" // 일본의사회
+                    // 일본 공식 기관
+                    "https://www.jrc.or.jp/activity/study/safety/", // 일본적십자사
+                    "https://www.fdma.go.jp/mission/prevention/kinkyu/", // 소방청 응급처치
+                    "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000121431.html", // 후생노동성
+                    "https://www.city.tokyo.lg.jp/shobo/anzen/topics/saigai/kyukyu/", // 도쿄소방청
+                    "https://www.med.or.jp/people/info/people_info/000380.html" // 일본의사회
             );
 
             case "zh" -> Arrays.asList(
-                // 중국 공식 기관
-                "https://www.redcross.org.cn/hhzh/jjhh/", // 중국적십자사
-                "https://www.nhc.gov.cn/jkj/s5899t/201801/80b5dfe8f2d144a4b3bb8f8e4dd8ae44.shtml",
-                // 국가위생건강위원회
-                "https://www.120ask.com/jijiu/", // 120응급의학망
-                "https://www.dxy.cn/bbs/forum/43", // 정안원 응급의학
-                "https://health.china.com/news/jijiu/" // 건강중국 응급처치
+                    // 중국 공식 기관
+                    "https://www.redcross.org.cn/hhzh/jjhh/", // 중국적십자사
+                    "https://www.nhc.gov.cn/jkj/s5899t/201801/80b5dfe8f2d144a4b3bb8f8e4dd8ae44.shtml",
+                    // 국가위생건강위원회
+                    "https://www.120ask.com/jijiu/", // 120응급의학망
+                    "https://www.dxy.cn/bbs/forum/43", // 정안원 응급의학
+                    "https://health.china.com/news/jijiu/" // 건강중국 응급처치
             );
 
             case "es" -> Arrays.asList(
-                // 스페인어권 응급처치 리소스
-                "https://www.cruzroja.es/principal/web/cruz-roja/inicio/-/botones/viewBotones/eyJjYXRlZ29yaWEiOiJmb3JtYWNpb24iLCJzdWJjYXRlZ29yaWEiOiJwcmltZXJvc19hdXhpbGlvcyJ9",
-                // 스페인 적십자
-                "https://www.sanidad.gob.es/ciudadanos/saludAmbLaboral/planEmergSanitarias/home.htm",
-                // 스페인 보건부
-                "https://medlineplus.gov/spanish/firstaid.html", // MedlinePlus 스페인어
-                "https://www.mayoclinic.org/es-es/first-aid", // Mayo Clinic 스페인어
-                "https://kidshealth.org/es/parents/firstaid-kit.html" // KidsHealth 스페인어
+                    // 스페인어권 응급처치 리소스
+                    "https://www.cruzroja.es/principal/web/cruz-roja/inicio/-/botones/viewBotones/eyJjYXRlZ29yaWEiOiJmb3JtYWNpb24iLCJzdWJjYXRlZ29yaWEiOiJwcmltZXJvc19hdXhpbGlvcyJ9",
+                    // 스페인 적십자
+                    "https://www.sanidad.gob.es/ciudadanos/saludAmbLaboral/planEmergSanitarias/home.htm",
+                    // 스페인 보건부
+                    "https://medlineplus.gov/spanish/firstaid.html", // MedlinePlus 스페인어
+                    "https://www.mayoclinic.org/es-es/first-aid", // Mayo Clinic 스페인어
+                    "https://kidshealth.org/es/parents/firstaid-kit.html" // KidsHealth 스페인어
             );
 
             case "fr" -> Arrays.asList(
-                // 프랑스어 응급처치 리소스
-                "https://www.croix-rouge.fr/Je-me-forme/Particuliers/Les-formations-aux-gestes-de-premiers-secours",
-                // 프랑스 적십자
-                "https://www.pompiers.fr/grand-public/gestes-de-premiers-secours", // 프랑스 소방청
-                "https://solidarites-sante.gouv.fr/soins-et-maladies/urgences/", // 프랑스 보건부
-                "https://www.ameli.fr/assure/sante/urgence/premiers-secours", // Ameli 보건보험
-                "https://www.federationdesante.fr/premiers-secours/" // 연방보건기구
+                    // 프랑스어 응급처치 리소스
+                    "https://www.croix-rouge.fr/Je-me-forme/Particuliers/Les-formations-aux-gestes-de-premiers-secours",
+                    // 프랑스 적십자
+                    "https://www.pompiers.fr/grand-public/gestes-de-premiers-secours", // 프랑스 소방청
+                    "https://solidarites-sante.gouv.fr/soins-et-maladies/urgences/", // 프랑스 보건부
+                    "https://www.ameli.fr/assure/sante/urgence/premiers-secours", // Ameli 보건보험
+                    "https://www.federationdesante.fr/premiers-secours/" // 연방보건기구
             );
 
             case "de" -> Arrays.asList(
-                // 독일어 응급처치 리소스
-                "https://www.drk.de/hilfe-in-deutschland/erste-hilfe/", // 독일 적십자
-                "https://www.malteser.de/aware/hilfreich/erste-hilfe-tipps.html", // 몰테세르 구조단
-                "https://www.bundesgesundheitsministerium.de/themen/praevention/gesundheitsgefahren/erste-hilfe.html",
-                // 독일 보건부
-                "https://www.johanniter.de/die-johanniter/johanniter-unfall-hilfe/was-wir-tun/erste-hilfe/",
-                // 요하니터 구조대
-                "https://www.apotheken-umschau.de/krankheiten-symptome/erste-hilfe" // 약국리뷰 응급처치
+                    // 독일어 응급처치 리소스
+                    "https://www.drk.de/hilfe-in-deutschland/erste-hilfe/", // 독일 적십자
+                    "https://www.malteser.de/aware/hilfreich/erste-hilfe-tipps.html", // 몰테세르 구조단
+                    "https://www.bundesgesundheitsministerium.de/themen/praevention/gesundheitsgefahren/erste-hilfe.html",
+                    // 독일 보건부
+                    "https://www.johanniter.de/die-johanniter/johanniter-unfall-hilfe/was-wir-tun/erste-hilfe/",
+                    // 요하니터 구조대
+                    "https://www.apotheken-umschau.de/krankheiten-symptome/erste-hilfe" // 약국리뷰 응급처치
             );
 
             case "ru" -> Arrays.asList(
-                // 러시아어 응급처치 리소스
-                "https://www.redcross.ru/education/first-aid", // 러시아 적십자
-                "https://www.mchs.gov.ru/ministerstvo/o-ministerstve/struktura/glavnye-upravleniya/glavnoe-upravlenie-meditsiny-katastrof",
-                // 비상사태부
-                "https://minzdrav.gov.ru/poleznaya-informatsiya/dlya-grazhdan/pervaya-pomoshch",
-                // 보건부
-                "https://www.rosminzdrav.ru/ministry/61/22/stranitsa-979/stranitsa-983/4-pervaya-meditsinskaya-pomoshch",
-                // 보건부 의료지원
-                "https://www.zdorovieinfo.ru/pervaya_pomoshch/" // 건강정보 포털
+                    // 러시아어 응급처치 리소스
+                    "https://www.redcross.ru/education/first-aid", // 러시아 적십자
+                    "https://www.mchs.gov.ru/ministerstvo/o-ministerstve/struktura/glavnye-upravleniya/glavnoe-upravlenie-meditsiny-katastrof",
+                    // 비상사태부
+                    "https://minzdrav.gov.ru/poleznaya-informatsiya/dlya-grazhdan/pervaya-pomoshch",
+                    // 보건부
+                    "https://www.rosminzdrav.ru/ministry/61/22/stranitsa-979/stranitsa-983/4-pervaya-meditsinskaya-pomoshch",
+                    // 보건부 의료지원
+                    "https://www.zdorovieinfo.ru/pervaya_pomoshch/" // 건강정보 포털
             );
 
             case "ar" -> Arrays.asList(
-                // 아랍어 응급처치 리소스
-                "https://www.redcrescent.org.ae/en/first-aid", // UAE 적신월사
-                "https://www.moh.gov.sa/HealthAwareness/MedicalTools/Pages/FirstAid.aspx",
-                // 사우디 보건부
-                "https://www.webteb.com/articles/%D8%A7%D9%84%D8%A5%D8%B3%D8%B9%D8%A7%D9%81%D8%A7%D8%AA-%D8%A7%D9%84%D8%A3%D9%88%D9%84%D9%8A%D8%A9",
-                // WebTeb 응급처치
-                "https://altibbi.com/%D9%85%D9%82%D8%A7%D9%84%D8%A7%D8%AA-%D8%B7%D8%A8%D9%8A%D8%A9/%D8%A7%D8%B3%D8%B9%D8%A7%D9%81%D8%A7%D8%AA-%D8%A3%D9%88%D9%84%D9%8A%D8%A9",
-                // الطبي 의학사이트
-                "https://www.mayoclinic.org/ar/first-aid" // Mayo Clinic 아랍어
+                    // 아랍어 응급처치 리소스
+                    "https://www.redcrescent.org.ae/en/first-aid", // UAE 적신월사
+                    "https://www.moh.gov.sa/HealthAwareness/MedicalTools/Pages/FirstAid.aspx",
+                    // 사우디 보건부
+                    "https://www.webteb.com/articles/%D8%A7%D9%84%D8%A5%D8%B3%D8%B9%D8%A7%D9%81%D8%A7%D8%AA-%D8%A7%D9%84%D8%A3%D9%88%D9%84%D9%8A%D8%A9",
+                    // WebTeb 응급처치
+                    "https://altibbi.com/%D9%85%D9%82%D8%A7%D9%84%D8%A7%D8%AA-%D8%B7%D8%A8%D9%8A%D8%A9/%D8%A7%D8%B3%D8%B9%D8%A7%D9%81%D8%A7%D8%AA-%D8%A3%D9%88%D9%84%D9%8A%D8%A9",
+                    // الطبي 의학사이트
+                    "https://www.mayoclinic.org/ar/first-aid" // Mayo Clinic 아랍어
             );
 
             case "hi" -> Arrays.asList(
-                // 힌디어 응급처치 리소스
-                "https://www.redcrossindia.org/first-aid.htm", // 인도 적십자
-                "https://www.mohfw.gov.in/", // 인도 보건가족복지부
-                "https://www.nhp.gov.in/first-aid-tips_pg", // 국가보건포털
-                "https://www.1mg.com/articles/first-aid-basics/", // 1mg 의학정보
-                "https://www.healthline.com/health/hi/first-aid" // Healthline 힌디어
+                    // 힌디어 응급처치 리소스
+                    "https://www.redcrossindia.org/first-aid.htm", // 인도 적십자
+                    "https://www.mohfw.gov.in/", // 인도 보건가족복지부
+                    "https://www.nhp.gov.in/first-aid-tips_pg", // 국가보건포털
+                    "https://www.1mg.com/articles/first-aid-basics/", // 1mg 의학정보
+                    "https://www.healthline.com/health/hi/first-aid" // Healthline 힌디어
             );
 
             default -> Arrays.asList(
-                // 영어 및 기본 국제 리소스
-                "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/anatomy-of-a-first-aid-kit",
-                // 미국 적십자
-                "https://www.mayoclinic.org/first-aid", // Mayo Clinic
-                "https://medlineplus.gov/firstaid.html", // MedlinePlus
-                "https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public",
-                // WHO
-                "https://www.healthline.com/health/first-aid-basics" // Healthline
+                    // 영어 및 기본 국제 리소스
+                    "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/anatomy-of-a-first-aid-kit",
+                    // 미국 적십자
+                    "https://www.mayoclinic.org/first-aid", // Mayo Clinic
+                    "https://medlineplus.gov/firstaid.html", // MedlinePlus
+                    "https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public",
+                    // WHO
+                    "https://www.healthline.com/health/first-aid-basics" // Healthline
             );
         };
     }
@@ -450,114 +472,114 @@ public class FirstAidService {
      * 증상별 특화된 리소스를 반환합니다.
      */
     private List<String> getSymptomSpecificResources(EmergencySymptomType symptomType,
-        String language) {
+                                                     String language) {
         Map<EmergencySymptomType, Map<String, List<String>>> symptomResources = Map.of(
 
-            EmergencySymptomType.BLEEDING, Map.of(
-                "ko", Arrays.asList(
-                    "https://www.119.go.kr/webapp/ptl/ptl010/ptl010_010100/ptl010_010100050/ptl010_010100050010/ptl010_010100050010.jsp",
-                    // 소방청 출혈
-                    "https://blog.naver.com/redcross_blog/221234567890" // 적십자 출혈 블로그
+                EmergencySymptomType.BLEEDING, Map.of(
+                        "ko", Arrays.asList(
+                                "https://www.119.go.kr/webapp/ptl/ptl010/ptl010_010100/ptl010_010100050/ptl010_010100050010/ptl010_010100050010.jsp",
+                                // 소방청 출혈
+                                "https://blog.naver.com/redcross_blog/221234567890" // 적십자 출혈 블로그
+                        ),
+                        "en", Arrays.asList(
+                                "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/cuts-scrapes",
+                                "https://www.mayoclinic.org/first-aid/first-aid-severe-bleeding/basics/art-20056661"
+                        ),
+                        "ja", Arrays.asList(
+                                "https://www.jrc.or.jp/activity/study/safety/rescue/knowledge/bleeding/",
+                                "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003002.html"
+                        )
                 ),
-                "en", Arrays.asList(
-                    "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/cuts-scrapes",
-                    "https://www.mayoclinic.org/first-aid/first-aid-severe-bleeding/basics/art-20056661"
-                ),
-                "ja", Arrays.asList(
-                    "https://www.jrc.or.jp/activity/study/safety/rescue/knowledge/bleeding/",
-                    "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003002.html"
-                )
-            ),
 
-            EmergencySymptomType.BURNS, Map.of(
-                "ko", Arrays.asList(
-                    "https://www.119.go.kr/webapp/ptl/ptl010/ptl010_010100/ptl010_010100050/ptl010_010100050020/ptl010_010100050020.jsp",
-                    // 소방청 화상
-                    "https://blog.severance.healthcare/burns-treatment" // 세브란스 화상 치료
+                EmergencySymptomType.BURNS, Map.of(
+                        "ko", Arrays.asList(
+                                "https://www.119.go.kr/webapp/ptl/ptl010/ptl010_010100/ptl010_010100050/ptl010_010100050020/ptl010_010100050020.jsp",
+                                // 소방청 화상
+                                "https://blog.severance.healthcare/burns-treatment" // 세브란스 화상 치료
+                        ),
+                        "en", Arrays.asList(
+                                "https://www.mayoclinic.org/first-aid/first-aid-burns/basics/art-20056649",
+                                "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/burns"
+                        ),
+                        "ja", Arrays.asList(
+                                "https://www.jrc.or.jp/activity/study/safety/rescue/knowledge/burns/",
+                                "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003003.html"
+                        )
                 ),
-                "en", Arrays.asList(
-                    "https://www.mayoclinic.org/first-aid/first-aid-burns/basics/art-20056649",
-                    "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/burns"
-                ),
-                "ja", Arrays.asList(
-                    "https://www.jrc.or.jp/activity/study/safety/rescue/knowledge/burns/",
-                    "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003003.html"
-                )
-            ),
 
-            EmergencySymptomType.FRACTURE, Map.of(
-                "ko", Arrays.asList(
-                    "https://www.119.go.kr/webapp/ptl/ptl010/ptl010_010100/ptl010_010100050/ptl010_010100050030/ptl010_010100050030.jsp",
-                    // 소방청 골절
-                    "https://blog.amc.seoul.kr/fracture-first-aid" // 서울아산병원 골절 블로그
+                EmergencySymptomType.FRACTURE, Map.of(
+                        "ko", Arrays.asList(
+                                "https://www.119.go.kr/webapp/ptl/ptl010/ptl010_010100/ptl010_010100050/ptl010_010100050030/ptl010_010100050030.jsp",
+                                // 소방청 골절
+                                "https://blog.amc.seoul.kr/fracture-first-aid" // 서울아산병원 골절 블로그
+                        ),
+                        "en", Arrays.asList(
+                                "https://www.mayoclinic.org/first-aid/first-aid-fractures/basics/art-20056641",
+                                "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/fractures"
+                        ),
+                        "ja", Arrays.asList(
+                                "https://www.jrc.or.jp/activity/study/safety/rescue/knowledge/fracture/",
+                                "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003004.html"
+                        )
                 ),
-                "en", Arrays.asList(
-                    "https://www.mayoclinic.org/first-aid/first-aid-fractures/basics/art-20056641",
-                    "https://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/fractures"
-                ),
-                "ja", Arrays.asList(
-                    "https://www.jrc.or.jp/activity/study/safety/rescue/knowledge/fracture/",
-                    "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003004.html"
-                )
-            ),
 
-            EmergencySymptomType.ALLERGIC_REACTION, Map.of(
-                "ko", Arrays.asList(
-                    "https://www.amc.seoul.kr/asan/healthinfo/disease/diseaseDetail.do?contentId=31484",
-                    // 서울아산병원 알레르기
-                    "https://blog.naver.com/allergy_korea/221876543210" // 알레르기 정보 블로그
+                EmergencySymptomType.ALLERGIC_REACTION, Map.of(
+                        "ko", Arrays.asList(
+                                "https://www.amc.seoul.kr/asan/healthinfo/disease/diseaseDetail.do?contentId=31484",
+                                // 서울아산병원 알레르기
+                                "https://blog.naver.com/allergy_korea/221876543210" // 알레르기 정보 블로그
+                        ),
+                        "en", Arrays.asList(
+                                "https://www.mayoclinic.org/first-aid/first-aid-anaphylaxis/basics/art-20056608",
+                                "https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/food-allergy-anaphylaxis-emergency-care-plan"
+                        ),
+                        "ja", Arrays.asList(
+                                "https://www.jaanet.org/patient/allergy_emergency.html",
+                                "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003005.html"
+                        )
                 ),
-                "en", Arrays.asList(
-                    "https://www.mayoclinic.org/first-aid/first-aid-anaphylaxis/basics/art-20056608",
-                    "https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/food-allergy-anaphylaxis-emergency-care-plan"
-                ),
-                "ja", Arrays.asList(
-                    "https://www.jaanet.org/patient/allergy_emergency.html",
-                    "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003005.html"
-                )
-            ),
 
-            EmergencySymptomType.SEIZURE, Map.of(
-                "ko", Arrays.asList(
-                    "https://www.snuh.org/health/nMedInfo/nView.do?category=DIS&medid=AA000408",
-                    // 서울대병원 간질
-                    "https://blog.epilepsy.or.kr/first-aid-seizure" // 한국뇌전증협회
+                EmergencySymptomType.SEIZURE, Map.of(
+                        "ko", Arrays.asList(
+                                "https://www.snuh.org/health/nMedInfo/nView.do?category=DIS&medid=AA000408",
+                                // 서울대병원 간질
+                                "https://blog.epilepsy.or.kr/first-aid-seizure" // 한국뇌전증협회
+                        ),
+                        "en", Arrays.asList(
+                                "https://www.mayoclinic.org/first-aid/first-aid-seizures/basics/art-20056695",
+                                "https://www.epilepsy.com/what-is-epilepsy/seizure-first-aid-and-safety"
+                        ),
+                        "ja", Arrays.asList(
+                                "https://www.jea-net.jp/patient/seizure-first-aid",
+                                "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003006.html"
+                        )
                 ),
-                "en", Arrays.asList(
-                    "https://www.mayoclinic.org/first-aid/first-aid-seizures/basics/art-20056695",
-                    "https://www.epilepsy.com/what-is-epilepsy/seizure-first-aid-and-safety"
-                ),
-                "ja", Arrays.asList(
-                    "https://www.jea-net.jp/patient/seizure-first-aid",
-                    "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003006.html"
-                )
-            ),
 
-            EmergencySymptomType.HEATSTROKE, Map.of(
-                "ko", Arrays.asList(
-                    "https://www.cdc.go.kr/contents.es?mid=a20301000000", // 질병관리청 열사병
-                    "https://blog.kweather.co.kr/heatstroke-prevention" // 기상청 열사병 예방
-                ),
-                "en", Arrays.asList(
-                    "https://www.mayoclinic.org/first-aid/first-aid-heat-exhaustion/basics/art-20056651",
-                    "https://www.cdc.gov/disasters/extremeheat/warning.html"
-                ),
-                "ja", Arrays.asList(
-                    "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/kenkou_iryou/kenkou/nettyuu/index.html",
-                    "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003007.html"
+                EmergencySymptomType.HEATSTROKE, Map.of(
+                        "ko", Arrays.asList(
+                                "https://www.cdc.go.kr/contents.es?mid=a20301000000", // 질병관리청 열사병
+                                "https://blog.kweather.co.kr/heatstroke-prevention" // 기상청 열사병 예방
+                        ),
+                        "en", Arrays.asList(
+                                "https://www.mayoclinic.org/first-aid/first-aid-heat-exhaustion/basics/art-20056651",
+                                "https://www.cdc.gov/disasters/extremeheat/warning.html"
+                        ),
+                        "ja", Arrays.asList(
+                                "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/kenkou_iryou/kenkou/nettyuu/index.html",
+                                "https://www.fdma.go.jp/mission/prevention/kinkyu/kq9003007.html"
+                        )
                 )
-            )
         );
 
         // 해당 증상과 언어에 맞는 리소스 반환
         return symptomResources
-            .getOrDefault(symptomType, Map.of())
-            .getOrDefault(language.toLowerCase(),
-                // 언어별 리소스가 없으면 영어 기본값
-                symptomResources
-                    .getOrDefault(symptomType, Map.of())
-                    .getOrDefault("en", Collections.emptyList())
-            );
+                .getOrDefault(symptomType, Map.of())
+                .getOrDefault(language.toLowerCase(),
+                        // 언어별 리소스가 없으면 영어 기본값
+                        symptomResources
+                                .getOrDefault(symptomType, Map.of())
+                                .getOrDefault("en", Collections.emptyList())
+                );
     }
 
 }

--- a/src/main/java/com/vitaltrip/vitaltrip/presentation/first_aid/dto/EmergencyChatAdviceResponse.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/presentation/first_aid/dto/EmergencyChatAdviceResponse.java
@@ -5,22 +5,35 @@ import com.vitaltrip.vitaltrip.presentation.location.dto.CountryIdentificationRe
 import java.util.List;
 
 public record EmergencyChatAdviceResponse(
-    String content,
-    String summary,
-    String recommendedAction,
-    CountryIdentificationResponse identificationResponse,
-    String disclaimer,
-    Integer confidence,
-    List<String> blogLinks
-) {
-
-    public static EmergencyChatAdviceResponse of(String content, String summary,
+        String content,
+        String summary,
         String recommendedAction,
         CountryIdentificationResponse identificationResponse,
         String disclaimer,
         Integer confidence,
-        List<String> blogLinks) {
-        return new EmergencyChatAdviceResponse(content, summary, recommendedAction,
-            identificationResponse, disclaimer, confidence, blogLinks);
+        List<String> blogLinks,
+        boolean aiAvailable
+) {
+
+    public static EmergencyChatAdviceResponse of(
+            String content, String summary, String recommendedAction,
+            CountryIdentificationResponse identificationResponse,
+            String disclaimer, Integer confidence, List<String> blogLinks) {
+        return new EmergencyChatAdviceResponse(
+                content, summary, recommendedAction, identificationResponse,
+                disclaimer, confidence, blogLinks, true);
+    }
+
+    public static EmergencyChatAdviceResponse unavailable(
+            CountryIdentificationResponse identificationResponse) {
+        return new EmergencyChatAdviceResponse(
+                null,
+                "AI 응급처치 가이드를 일시적으로 제공할 수 없습니다.",
+                "아래 응급 번호로 즉시 연락하십시오.",
+                identificationResponse,
+                "본 서비스는 전문 의료 처치를 대신할 수 없습니다.",
+                null,
+                List.of(),
+                false);
     }
 }

--- a/src/main/java/com/vitaltrip/vitaltrip/presentation/location/dto/CountryIdentificationResponse.java
+++ b/src/main/java/com/vitaltrip/vitaltrip/presentation/location/dto/CountryIdentificationResponse.java
@@ -3,40 +3,46 @@ package com.vitaltrip.vitaltrip.presentation.location.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CountryIdentificationResponse(
-    @Schema(description = "ISO 3166-1 alpha-2 국가 코드", example = "KR")
-    String countryCode,
+        @Schema(description = "ISO 3166-1 alpha-2 국가 코드", example = "KR")
+        String countryCode,
 
-    @Schema(description = "국가명 (영어)", example = "South Korea")
-    String countryName,
+        @Schema(description = "국가명 (영어)", example = "South Korea")
+        String countryName,
 
-    @Schema(description = "입력된 위도", example = "37.5665")
-    Double latitude,
+        @Schema(description = "입력된 위도", example = "37.5665")
+        Double latitude,
 
-    @Schema(description = "입력된 경도", example = "126.9780")
-    Double longitude,
+        @Schema(description = "입력된 경도", example = "126.9780")
+        Double longitude,
 
-    @Schema(description = "국가 응급 번호",
-        example = """
-            {
-              "fire": "119",
-              "police": "112", 
-              "medical": "119",
-              "general": "112"
-            }
-            """)
-    EmergencyContact emergencyContact
+        @Schema(description = "국가 응급 번호",
+                example = """
+                        {
+                          "fire": "119",
+                          "police": "112", 
+                          "medical": "119",
+                          "general": "112"
+                        }
+                        """)
+        EmergencyContact emergencyContact
 ) {
 
     public static CountryIdentificationResponse from(BigDataCloudResponse response,
-        Double inputLatitude,
-        Double inputLongitude,
-        EmergencyContact emergencyContact) {
+                                                     Double inputLatitude,
+                                                     Double inputLongitude,
+                                                     EmergencyContact emergencyContact) {
         return new CountryIdentificationResponse(
-            response.countryCode(),
-            response.countryName(),
-            inputLatitude,
-            inputLongitude,
-            emergencyContact
+                response.countryCode(),
+                response.countryName(),
+                inputLatitude,
+                inputLongitude,
+                emergencyContact
         );
+    }
+
+    public static CountryIdentificationResponse unknown(double latitude, double longitude) {
+        return new CountryIdentificationResponse(
+                null, null, latitude, longitude,
+                EmergencyContact.of("112", "112", "112", "112"));
     }
 }

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -1,3 +1,18 @@
+resilience4j:
+  circuitbreaker:
+    instances:
+      gemini:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        failure-rate-threshold: 50
+        slow-call-duration-threshold: 8s
+        slow-call-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        automatic-transition-from-open-to-half-open-enabled: true
+        register-health-indicator: true
+
 spring:
   datasource:
     url: jdbc:mysql://db:3306/vitaltrip?characterEncoding=UTF-8&connectionTimeZone=Asia/Seoul
@@ -48,10 +63,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,threaddump,heapdump,loggers
+        include: health,metrics,circuitbreakers
       base-path: /actuator
   endpoint:
     health:
+      circuitbreakers:
+        enabled: true
       show-details: always
       probes:
         enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       - classpath:config/ai.yml
       - classpath:config/places.yml
       - classpath:config/news.yml
+      - classpath:config/resilience.yml
 
 server:
   port: ${SERVER_PORT:8080}

--- a/src/main/resources/config/resilience.yml
+++ b/src/main/resources/config/resilience.yml
@@ -1,0 +1,14 @@
+resilience4j:
+  circuitbreaker:
+    instances:
+      gemini:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        failure-rate-threshold: 50
+        slow-call-duration-threshold: 8s
+        slow-call-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        automatic-transition-from-open-to-half-open-enabled: true
+        register-health-indicator: true


### PR DESCRIPTION
## 🚩 연관 이슈

closed #92 

## 📝 작업 내용
# 부하 테스트

응급처치 가이드 API(`POST /api/first-aid/advice`)의 외부 의존성 검증 환경입니다.

이 API는 요청 하나에 BigDataCloud(국가 판별)와 Gemini(가이드 생성)를 거치므로, 응답 시간의 대부분이 외부 서비스에 종속됩니다. 외부 지연이 서비스 전체로 전파되는지 확인하고 대응 조치의 효과를 측정합니다.

## 실행

```bash
./gradlew bootJar
docker compose -f docker-compose.loadtest.yml up -d --build

k6 run k6/first-aid/baseline.js
k6 run k6/first-aid/fault-isolation.js
```

| 서비스 | 포트 | 역할 |
| --- | --- | --- |
| app | 8080 / 9090 | 애플리케이션 / 액추에이터 |
| stub | 8090 | WireMock (외부 API 대체) |

## 외부 API 대체

실제 API로는 과금·쿼터 문제도 있지만, 무엇보다 **"Gemini가 60초 걸리는 상황"을 만들 수 없습니다.** WireMock은 응답에 지연 시간을 지정할 수 있어, 애플리케이션의 외부 API 주소만 바꿔 끼우면 코드 수정 없이 장애를 재현할 수 있습니다.

`wiremock/mappings/` 아래에 매핑이 있습니다.

| 파일 | 대상 | 기본 지연 |
| --- | --- | --- |
| `gemini.json` | Gemini generateContent | 4000ms |
| `bigdatacloud.json` | 좌표 → 국가 판별 | 300ms |
| `catch-all.json` | 정의되지 않은 경로 → 599 | - |

`catch-all.json`이 없으면 스텁 설정에 오타가 있어도 404가 반환되고, 애플리케이션은 이를 정상적인 실패로 처리합니다. 테스트가 통과했는데 실제로는 아무것도 검증하지 못하는 상태를 막기 위한 장치입니다.

## 스크립트

### baseline.js

VU 1로 2분간 순차 호출해 부하 없는 상태의 응답 시간을 측정합니다. **p95 4.32초** — 스텁 지연 4초에 서버 처리 0.31초를 더한 값이며, 이 기능의 이론적 최소 응답 시간입니다. 이후 모든 측정의 비교 기준이 됩니다.

### fault-isolation.js

10분간 네 시나리오를 병렬로 실행합니다.

| 시나리오 | 역할 |
| --- | --- |
| `firstAidLoad` | 응급처치 API에 4 rps 고정 부하 |
| `faultInjection` | 2분에 Gemini를 60초 지연으로 전환, 5분에 복구 |
| `canary` | `GET /` 호출 — Gemini와 무관한 엔드포인트 |
| `monitor` | 스레드 점유, 서킷 브레이커 상태 관측 |

canary: `GET /`는 DB도 외부 API도 거치지 않으므로, 이 엔드포인트가 느려진다면 원인은 스레드를 받지 못하는 것뿐입니다.

## 측정 결과

동일한 스크립트로 세 단계를 측정했습니다.

| 지표 | 조치 없음 | 타임아웃 8s | + 서킷 브레이커 |
| --- | --- | --- | --- |
| 응답 시간 중앙값 | 4.3s | 4.3s | **304ms** |
| 응답 시간 p95 | 1m 0s | 8.31s | **4.3s** |
| 요청 실패율 | 0.03% | 21.7% | **0%** |
| canary p95 | 1.55s | 3.29ms | **2.89ms** |
| 회복 자동 감지 | 불가 | 불가 | **22초** |

**조치 없음** — 스레드 점유가 최대치 200에 도달했고, Gemini를 호출하지 않는 `GET /`의 p95가 1.55초까지 올랐습니다. 장애 전파가 확인됩니다.

**타임아웃** — canary가 평상시 수준을 회복했습니다. 실패율 증가는 의도된 결과입니다. 60초 뒤에 오는 응급처치 가이드는 이미 의미가 없으므로, 8초 초과 호출을 포기하는 대신 다른 기능의 가용성을 확보했습니다. 다만 p90~p99가 모두 8.31초로, 장애 구간의 모든 요청이 8초를 대기한 뒤 실패했습니다.

**서킷 브레이커** — 중앙값이 304ms로 떨어졌고, p95는 정상 응답 시간과 같아졌습니다. 8초를 채운 요청은 HALF_OPEN에서 회복을 확인하려고 통과시킨 소수뿐입니다.

실패율 0%는 장애가 없었다는 뜻이 아닙니다. `fallback_rate` 33.5% — 요청의 3분의 1은 AI 응답 대신 응급 연락처 안내를 받습니다.

## ✨ 참고 사항

## ⏰ 현재 버그

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
